### PR TITLE
Change DB instance naming

### DIFF
--- a/lambda/index_patch.py
+++ b/lambda/index_patch.py
@@ -110,7 +110,7 @@ def handler(event, context):
                 num_to_create = desired_count - num_available
                 for idx in range(num_to_create):
                     docdb.create_db_instance(
-                        DBInstanceIdentifier=readers[0] + '-' + str(idx) + '-' + str(int(time.time())),
+                        DBInstanceIdentifier='reader-instance-' + str(idx) + '-' + str(int(time.time())),
                         DBInstanceClass=reader_type,
                         Engine=reader_engine,
                         DBClusterIdentifier=cluster_id


### PR DESCRIPTION
Use cluster ID as a prefix of DB instance name

*Issue #, if available:*

*Description of changes:*

If an existing reader's name is used as a prefix for a new reader's name, `DBInstanceIdentifier` may become longer than 63 characters as the scale-out event is repeated, resulting in failure to create a new reader instance.

- example case

original reader name: document-db-0
after first scale-out event: document-db-0-0-1643317240
after second scale-out event: document-db-0-0-1643317240-0-1643647240
after third scale-out event: document-db-0-0-1643317240-0-1643647240-0-1644647240
...


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

